### PR TITLE
Allow reactor chaining

### DIFF
--- a/lib/godot/reactor/console.js
+++ b/lib/godot/reactor/console.js
@@ -32,5 +32,5 @@ util.inherits(Console, ReadWriteStream);
 //
 Console.prototype.write = function (data) {
   this.formatFn(data);
-  return true;
+  return this.emit('data', data);
 };


### PR DESCRIPTION
Allow reactor chaining for example console + irc

``` javascript
godot.createServer({
  type: 'tcp',
  reactors: [
    godot.reactor()
      .console()
      .irc({
         ...
      })
  ]
}).listen(1337);
```
