### PR TITLE
Added os.hostname() to be the default host for the producer

### DIFF
--- a/lib/godot/producer/producer.js
+++ b/lib/godot/producer/producer.js
@@ -7,7 +7,8 @@
 
 var stream = require('stream'),
     utile = require('utile'),
-    uuid = require('node-uuid');
+    uuid = require('node-uuid'),
+    os = require('os');
 
 //
 // ### function Producer (options)
@@ -21,9 +22,6 @@ var Producer = module.exports = function Producer(options) {
 
   var self = this;
 
-  //
-  // TODO: Use the default host for the running process.
-  //
   this.id       = uuid.v4();
   this.readable = true;
   this.values   = {};
@@ -58,6 +56,7 @@ utile.inherits(Producer, stream.Stream);
 // emitted by this instance.
 //
 Producer.prototype.defaults = {
+  host:         os.hostname(),
   state:       'ok',
   description: 'No description',
   tags:        [],


### PR DESCRIPTION
This felt far too easy for #3 but let me know.
