### PR TITLE
Add "meta" property to event data and associated Reactors

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ Similar to [Riemann][riemann], events in `godot` are simply JSON sent over UDP o
     state:        "Any string less than 255 bytes, e.g. 'ok', 'warning', 'critical'",
     time:         "The time of the event, in unix epoch seconds",
     description:  "Freeform text",
-    tags:         "Freeform list of strings, e.g. ['rate', 'fooproduct', 'transient']"
-    metric:       "A number associated with this event, e.g. the number of reqs/sec."
+    tags:         "Freeform list of strings, e.g. ['rate', 'fooproduct', 'transient']",
+    meta:         "Freeform set of key:value pairs e.g. { 'ewma': 12345 }",
+    metric:       "A number associated with this event, e.g. the number of reqs/sec.",
     ttl:          "A floating-point time, in seconds, that this event is considered valid for."
   }
 ```

--- a/lib/godot.js
+++ b/lib/godot.js
@@ -27,6 +27,13 @@ exports.reactor  = require('./godot/reactor');
 exports.producer = require('./godot/producer');
 
 //
+// ### @common {Object}
+// Expose `common` module for performing basic
+// streaming.
+//
+exports.common = require('./godot/common');
+
+//
 // ### @math {Object}
 // Expose `math` module for performing basic
 // math on sets of events.

--- a/lib/godot/common/index.js
+++ b/lib/godot/common/index.js
@@ -29,3 +29,9 @@ exports.ReadWriteStream = require('./read-write-stream');
 // Constructor function for the godot streaming JsonParser
 //
 exports.JsonParser = require('./json-parser');
+
+//
+// ### @FilterStream {function}
+// Constructor function for the base FilterStream
+//
+exports.FilterStream = require('./filter-stream');

--- a/lib/godot/reactor/all-meta.js
+++ b/lib/godot/reactor/all-meta.js
@@ -1,0 +1,25 @@
+/*
+ * all-meta.js: Stream for filtering events with a given meta key (or set of keys).
+ *
+ * (C) 2012, Nodejitsu Inc.
+ *
+ */
+
+var util = require('util'),
+    HasMeta = require('./has-meta');
+
+//
+// ### function AllMeta (keys|key0, key1, ..., keyN)
+// #### @keys|key0..keyN {Array|arguments} Full set of keys to filter over.
+// Constructor function of the AllMeta stream responsible for filtering
+// events with any of a given key (or set of keys).
+//
+var AllMeta = module.exports = function () {
+  HasMeta.apply(this, arguments);
+  this.type = 'all';
+};
+
+//
+// Inherit from HasMeta reactor.
+//
+util.inherits(AllMeta, HasMeta);

--- a/lib/godot/reactor/any-meta.js
+++ b/lib/godot/reactor/any-meta.js
@@ -1,0 +1,25 @@
+/*
+ * any-meta.js: Stream for filtering events with any of a given meta key (or set of keys).
+ *
+ * (C) 2012, Nodejitsu Inc.
+ *
+ */
+
+var util = require('util'),
+    HasMeta = require('./has-meta');
+
+//
+// ### function AnyMeta (keys|key0, key1, ..., keyN)
+// #### @keys|key0..keyN {Array|arguments} Full set of keys to filter over.
+// Constructor function of the AnyMeta stream responsible for filtering
+// events with any of a given key (or set of keys).
+//
+var AnyMeta = module.exports = function () {
+  HasMeta.apply(this, arguments);
+  this.type = 'any';
+};
+
+//
+// Inherit from HasMeta reactor.
+//
+util.inherits(AnyMeta, HasMeta);

--- a/lib/godot/reactor/has-meta.js
+++ b/lib/godot/reactor/has-meta.js
@@ -1,0 +1,77 @@
+/*
+ * has-meta.js: Stream for filtering events with a given meta key (or set of keys).
+ *
+ * (C) 2012, Nodejitsu Inc.
+ *
+ */
+
+var util = require('util'),
+    ReadWriteStream = require('../common/read-write-stream');
+
+//
+// ### function HasMeta ([type], keys|key0, key, ..., keyN)
+// #### @type {any|all} Type of tag filtering to perform: any or all. 
+// #### @keys|key0..keyN {Array|arguments} Full set of keys to filter over.
+// Constructor function of the HasMeta stream responsible for filtering
+// events with a given meta key (or set of keys).
+//
+var HasMeta = module.exports = function (type) {
+  ReadWriteStream.call(this);
+  
+  var keys = Array.prototype.slice.call(arguments);
+  
+  if (type === 'any' || type === 'all') {
+    this.type = type;
+    keys.splice(0, 1);
+  }
+  else {
+    this.type === 'any';
+  }
+
+  this.keys = keys.reduce(function (all, key) {
+    if (Array.isArray(key)) {
+      all = all.concat(key);
+    }
+    else {
+      all.push(key);
+    }
+    
+    return all;
+  }, []);
+};
+
+//
+// Inherit from ReadWriteStream
+//
+util.inherits(HasMeta, ReadWriteStream);
+
+//
+// ### function write (data)
+// #### @data {Object} JSON to rollup.
+// Only filters `data` according to `this.keys`.
+//
+HasMeta.prototype.write = function (data) {
+  //
+  // If there are no tags on the data return
+  //
+  if (!data.meta) {
+    return;
+  }
+  
+  //
+  // Helper function for checking a given `key`.
+  //
+  function hasKey(key) {
+    return data.meta[key] !== undefined;
+  }
+  
+  var valid = this.type === 'all'
+    ? this.keys.every(hasKey)
+    : this.keys.some(hasKey);
+    
+  if (!valid) {
+    return;
+  }
+  
+  this.emit('data', data);
+};

--- a/lib/godot/reactor/has-meta.js
+++ b/lib/godot/reactor/has-meta.js
@@ -28,16 +28,33 @@ var HasMeta = module.exports = function (type) {
     this.type === 'any';
   }
 
-  this.keys = keys.reduce(function (all, key) {
+  //
+  // Create a lookup table of any values provided.
+  // If no value is provided set the key to `null`
+  // since we will be checking for `undefined`.
+  //
+  this.lookup = keys.reduce(function (all, key) {
     if (Array.isArray(key)) {
-      all = all.concat(key);
+      key.forEach(function (kkey) {
+        all[kkey] = null;
+      });
+    }
+    else if (typeof key === 'object') {
+      Object.keys(key).forEach(function (kkey) {
+        all[kkey] = key[kkey];
+      });
     }
     else {
-      all.push(key);
+      all[key] = null;
     }
-    
+
     return all;
-  }, []);
+  }, {});
+  
+  //
+  // Store the list of keys for iterating over later.
+  //
+  this.keys = Object.keys(this.lookup);
 };
 
 //
@@ -51,6 +68,8 @@ util.inherits(HasMeta, ReadWriteStream);
 // Only filters `data` according to `this.keys`.
 //
 HasMeta.prototype.write = function (data) {
+  var self = this;
+
   //
   // If there are no tags on the data return
   //
@@ -62,7 +81,9 @@ HasMeta.prototype.write = function (data) {
   // Helper function for checking a given `key`.
   //
   function hasKey(key) {
-    return data.meta[key] !== undefined;
+    return data.meta[key] !== undefined
+      && (self.lookup[key] === null ||
+      self.lookup[key] === data.meta[key]);
   }
   
   var valid = this.type === 'all'

--- a/lib/godot/reactor/meta.js
+++ b/lib/godot/reactor/meta.js
@@ -1,0 +1,50 @@
+/*
+ * meta.js: Stream for setting the value (and any meta) from a second reactor on any data received.
+ *
+ * (C) 2013, Nodejitsu Inc.
+ *
+ */
+
+var util = require('util'),
+    ReadWriteStream = require('../common/read-write-stream'),
+    Reactor = require('./reactor');
+
+//
+// ### function Meta (tag, reactor)
+// #### @key {string} Meta key to use for the value of `reactor`.
+// #### @reactor {godot.reactor().type()} Reactor to be created
+// Constructor function for the Meta stream responsible for setting
+// the value (and any meta) from a second reactor on any data received.
+//
+var Meta = module.exports = function (key, reactor) {
+  ReadWriteStream.call(this);
+
+  var self = this;
+
+  this.key     = key;
+  this.stream  = new ReadWriteStream();
+  this.reactor = reactor.createStream(this.stream);
+  this.reactor.on('data', function (data) {
+    data.meta      = data.meta || {};
+    data.meta[key] = data.metric;
+    data.metric    = data._metric;
+    delete data._metric;
+    self.emit('data', data);
+  });
+};
+
+//
+// Inherit from ReadWriteStream
+//
+util.inherits(Meta, ReadWriteStream);
+
+//
+// ### function write (data)
+// Writes the `data` to the meta stream associated
+// with this instance and sets `_metric` so it can
+// be replaced later on.
+//
+Meta.prototype.write = function (data) {
+  data._metric = data.metric;
+  this.stream.write(data);
+};

--- a/test/fixtures/meta.json
+++ b/test/fixtures/meta.json
@@ -1,0 +1,82 @@
+[
+  {
+    "service": "charlie/app/health/ping",
+    "metric": 1,
+    "meta": {
+      "a": 1,
+      "b": 1,
+      "c": 1
+    }
+  },
+  {
+    "service": "charlie/app/health/ping",
+    "metric": 1,
+    "meta": {
+      "a": 1
+    }
+  },
+  {
+    "service": "charlie/app/health/ping",
+    "metric": 1,
+    "meta": {
+      "a": 1,
+      "b": 1,
+      "c": 1
+    }
+  },
+  {
+    "service": "charlie/app/health/ping",
+    "metric": 1,
+    "meta": {
+      "a": 1
+    }
+  },
+  {
+    "service": "charlie/app/health/ping",
+    "metric": 1,
+    "meta": {
+      "a": 1,
+      "b": 1,
+      "c": 1
+    }
+  },
+  {
+    "service": "charlie/app/health/ping",
+    "metric": 1,
+    "meta": {
+      "a": 1
+    }
+  },
+  {
+    "service": "charlie/app/health/ping",
+    "metric": 1,
+    "meta": {
+      "a": 1,
+      "b": 1,
+      "c": 1
+    }
+  },
+  {
+    "service": "charlie/app/health/ping",
+    "metric": 1,
+    "meta": {
+      "a": 1
+    }
+  },
+  {
+    "service": "charlie/app/health/ping",
+    "metric": 1,
+    "meta": {
+      "a": 1,
+      "b": 1,
+      "c": 1
+    }
+  },
+  {
+    "service": "charlie/app/health/ping",
+    "metric": 1,
+    "meta": {
+      "a": 1
+    }
+  }
+]

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -58,10 +58,22 @@ exports.timeSeries = function (event, length, duration) {
       now = +Date.now();
 
   return range(1, intervals).map(function (interval) {
-    return Object.keys(event).reduce(function (obj, key) {
-      obj[key] = typeof event[key] === 'function'
-        ? event[key](interval)
-        : event[key]
+    return Object.keys(event).reduce(function reduceKey(obj, key) {
+      if (typeof event[key] === 'function') {
+        obj[key] = event[key](interval)
+      }
+      else if (Array.isArray(event[key])) {
+        obj[key] = event[key].slice();
+      }
+      else if (typeof event[key] === 'object') {
+        obj[key] = Object.keys(event[key]).reduce(function (value, kkey) {
+          value[kkey] = event[key][kkey];
+          return value;
+        }, {});
+      }
+      else {
+        obj[key] = event[key];
+      }
 
       return obj;
     }, { time: now + (interval * duration) });

--- a/test/reactor/meta-test.js
+++ b/test/reactor/meta-test.js
@@ -80,34 +80,98 @@ vows.describe('godot/reactor/meta').addBatch({
       }
     },
     "hasMeta": {
-      "all": macros.shouldEmitDataSync(
+      "all": {
+        "with only keys": macros.shouldEmitDataSync(
+          godot
+            .reactor()
+            .hasMeta('all', 'a', 'b', 'c'),
+          'meta',
+          5
+        ),
+        "with all values": macros.shouldEmitDataSync(
+          godot
+            .reactor()
+            .hasMeta('all', { a: 1, b: 1, c: 1 }),
+          'meta',
+          5
+        ),
+        "with keys and values": macros.shouldEmitDataSync(
+          godot
+            .reactor()
+            .hasMeta('all', { a: 1 }, 'b', 'c'),
+          'meta',
+          5
+        ),
+      },
+      "any": {
+        "with only keys": macros.shouldEmitDataSync(
+          godot
+            .reactor()
+            .hasMeta('any', 'a'),
+          'meta',
+          10
+        ),
+        "with all values": macros.shouldEmitDataSync(
+          godot
+            .reactor()
+            .hasMeta('any', { a: 1, b: 0, c: 0 }),
+          'meta',
+          10
+        ),
+        "with keys and values": macros.shouldEmitDataSync(
+          godot
+            .reactor()
+            .hasMeta('any', 'a', { b: 0, c: 0 }),
+          'meta',
+          10
+        ),
+      }
+    },
+    "anyMeta": {
+      "with only keys": macros.shouldEmitDataSync(
         godot
           .reactor()
-          .hasMeta('all', 'a', 'b', 'c'),
+          .anyMeta('a'),
+        'meta',
+        10
+      ),
+      "with all values": macros.shouldEmitDataSync(
+        godot
+          .reactor()
+          .anyMeta({ a: 1, b: 0, c: 0 }),
+        'meta',
+        10
+      ),
+      "with keys and values": macros.shouldEmitDataSync(
+        godot
+          .reactor()
+          .anyMeta('a', { b: 0, c: 0 }),
+        'meta',
+        10
+      ),
+    },
+    "allMeta": {
+      "with only keys": macros.shouldEmitDataSync(
+        godot
+          .reactor()
+          .allMeta('a', 'b', 'c'),
         'meta',
         5
       ),
-      "any": macros.shouldEmitDataSync(
+      "with all values": macros.shouldEmitDataSync(
         godot
           .reactor()
-          .hasMeta('any', 'a'),
+          .allMeta({ a: 1, b: 1, c: 1 }),
         'meta',
-        10
-      )
-    },
-    "anyMeta": macros.shouldEmitDataSync(
-      godot
-        .reactor()
-        .anyMeta('a'),
-      'meta',
-      10
-    ),
-    "allMeta": macros.shouldEmitDataSync(
-      godot
-        .reactor()
-        .allMeta('a', 'b', 'c'),
-      'meta',
-      5
-    )
+        5
+      ),
+      "with keys and values": macros.shouldEmitDataSync(
+        godot
+          .reactor()
+          .allMeta({ a: 1 }, 'b', 'c'),
+        'meta',
+        5
+      ),
+    }
   }
 }).export(module);

--- a/test/reactor/meta-test.js
+++ b/test/reactor/meta-test.js
@@ -1,0 +1,113 @@
+/*
+ * meta-test.js: Tests for the Meta reactor stream.
+ *
+ * (C) 2012, Nodejitsu Inc.
+ *
+ */
+
+var assert = require('assert'),
+    vows = require('vows'),
+    range = require('r...e'),
+    windowStream = require('window-stream'),
+    godot = require('../../lib/godot'),
+    helpers = require('../helpers'),
+    macros = require('../macros').reactor;
+
+var M1_ALPHA = 1 - Math.exp(-5/60);
+
+//
+// Local test macro for ensuring that meta data for a
+// simple average is added to the appropriate
+// `timeSeries`.
+//
+function shouldAddSimpleAverage(timeSeries, assertFn) {
+  return macros.shouldEmitDataSync(
+    godot
+      .reactor()
+      .meta('avg', godot.reactor().movingAverage({
+        average: 'simple',
+        window: new windowStream.EventWindow({ size: 10 })
+      })),
+    timeSeries,
+    100,
+    function (all) {
+      all.forEach(function (data, i) {
+        var num = data.metric,
+            di  = i + 1,
+            avg, set;
+
+        set = di < 10
+          ? range(1, di)
+          : range(di - 9, di);
+
+        assert.isObject(data.meta);
+        if (assertFn) {
+          assertFn(data);
+        }
+        
+        avg = data.meta.avg;
+        assert.equal(num, di);
+        assert.equal(avg, godot.math.mean(set.toArray().map(function (n) {
+          return { metric: n };
+        })));
+      });
+    }
+  )
+}
+
+vows.describe('godot/reactor/meta').addBatch({
+  "Godot": {
+    "meta": {
+      "with a simple movingAverage": {
+        "with existing meta": shouldAddSimpleAverage(
+          helpers.timeSeries({
+            meta: { foo: 'bar' },
+            metric: function (num) {
+              return num;
+            }
+          }, 1000, 10),
+          function (data) {
+            assert.equal(data.meta.foo, 'bar');
+          }
+        ),
+        "with no existing meta": shouldAddSimpleAverage(
+          helpers.timeSeries({
+            metric: function (num) {
+              return num;
+            }
+          }, 1000, 10)
+        )
+      }
+    },
+    "hasMeta": {
+      "all": macros.shouldEmitDataSync(
+        godot
+          .reactor()
+          .hasMeta('all', 'a', 'b', 'c'),
+        'meta',
+        5
+      ),
+      "any": macros.shouldEmitDataSync(
+        godot
+          .reactor()
+          .hasMeta('any', 'a'),
+        'meta',
+        10
+      )
+    },
+    "anyMeta": macros.shouldEmitDataSync(
+      godot
+        .reactor()
+        .anyMeta('a'),
+      'meta',
+      10
+    ),
+    "allMeta": macros.shouldEmitDataSync(
+      godot
+        .reactor()
+        .allMeta('a', 'b', 'c'),
+      'meta',
+      5
+    )
+  }
+}).export(module);


### PR DESCRIPTION
This adds a relatively simple new field to all events:

> {  ... meta:  "Freeform set of key:value pairs e.g. { 'ewma': 12345 }", ... }

I came across this problem when working on a relatively simple use-case:

> Emit data when the metric is one (or more) standard deviations above 
> (or below) the EWMA of the same metric.

To make this decision you need to know the `metric`, the `ewma` and the `stdDev`. Before adding `meta` I was having the `ewma` stream simply attach tags:

``` js
  {
    // ...
    "tags": ["ewma:12345.67", "stdDev:234.5"],
    // ...
  }
```

This is all well and good, but it felt wrong to be serializing and deserializing these values later on in the stream processing pipeline. With `meta` I end up with:

``` js
  {
    // ...
    "meta": {
      "ewma": 12345.67, 
      "stdDev": 234.5
    }
    // ...
  }
```

and don't have to deserialize again. 
