### PR TITLE
[fix] have map reactor handle an error event if it is async and errors

### DIFF
--- a/lib/godot/reactor/map.js
+++ b/lib/godot/reactor/map.js
@@ -42,8 +42,8 @@ Map.prototype.write = function (data) {
   }
 
   this.mapFn(data, function (err, data) {
-    if (!err) {
-      self.emit('data', data);
-    }
+    return err
+      ? self.emit('error', err)
+      : self.emit('data', data);
   });
 };


### PR DESCRIPTION
Small fix, any reason not to do this?
