### PR TITLE
Remove return statement in console reactor

### DIFF
--- a/lib/godot/reactor/console.js
+++ b/lib/godot/reactor/console.js
@@ -32,5 +32,5 @@ util.inherits(Console, ReadWriteStream);
 //
 Console.prototype.write = function (data) {
   this.formatFn(data);
-  return this.emit('data', data);
+  this.emit('data', data);
 };


### PR DESCRIPTION
Otherwise, if data isn't consumed afterwards, a `pipe`d source will be paused after the first event. 

Explanation: `emit` returns false if the event isn't handled, `pipe` pauses the source stream when the target's `write` method returns false.
